### PR TITLE
Update tests so they run on private DCore node

### DIFF
--- a/DCoreKit.xcodeproj/project.pbxproj
+++ b/DCoreKit.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		0721B48A227318BC009931BF /* BrainKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0721B488227318BC009931BF /* BrainKeyTests.swift */; };
 		0721B48C227318D6009931BF /* EnglishWordList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0721B48B227318D6009931BF /* EnglishWordList.swift */; };
 		0721B48D227318D6009931BF /* EnglishWordList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0721B48B227318D6009931BF /* EnglishWordList.swift */; };
+		07302CA822DE14AB008A4E5D /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07302CA722DE14AB008A4E5D /* Constants.swift */; };
+		07302CA922DE14AB008A4E5D /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07302CA722DE14AB008A4E5D /* Constants.swift */; };
 		07542DCC22770D8100101271 /* SeedDictionary.txt in Resources */ = {isa = PBXBuildFile; fileRef = 0721B4942276FDE4009931BF /* SeedDictionary.txt */; };
 		07542DCE22770D9900101271 /* SeedDictionary.txt in Resources */ = {isa = PBXBuildFile; fileRef = 0721B4942276FDE4009931BF /* SeedDictionary.txt */; };
 		07871B1222D5FE0900177B31 /* ContentApiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07871B1122D5FE0900177B31 /* ContentApiTests.swift */; };
@@ -683,6 +685,7 @@
 		0721B488227318BC009931BF /* BrainKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrainKeyTests.swift; sourceTree = "<group>"; };
 		0721B48B227318D6009931BF /* EnglishWordList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnglishWordList.swift; sourceTree = "<group>"; };
 		0721B4942276FDE4009931BF /* SeedDictionary.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = SeedDictionary.txt; sourceTree = "<group>"; };
+		07302CA722DE14AB008A4E5D /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		07871B1122D5FE0900177B31 /* ContentApiTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentApiTests.swift; sourceTree = "<group>"; };
 		07C36F49226F6D7500E9080D /* TransactionApiTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionApiTests.swift; sourceTree = "<group>"; };
 		07ECC50822B271F200B8A216 /* DCoreKit.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = DCoreKit.modulemap; sourceTree = "<group>"; };
@@ -1868,6 +1871,7 @@
 			children = (
 				071AE0422212CCC3008AE077 /* QR */,
 				A19D4CF521F1B4BD0069B6CA /* Utils */,
+				07302CA722DE14AB008A4E5D /* Constants.swift */,
 				OBJ_231 /* AccountApiTests.swift */,
 				A19D4CF221F1AE960069B6CA /* AccountApiMockTests.swift */,
 				A1673B4E21EF3CC3008FF560 /* OperationApiTests.swift */,
@@ -2924,6 +2928,7 @@
 				OBJ_1086 /* Sources */,
 				A112250621FB076E0023E49B /* Carthage */,
 				OBJ_1094 /* Frameworks */,
+				078312EA22DF15B100B22BCE /* Start DCore */,
 			);
 			buildRules = (
 			);
@@ -2992,6 +2997,24 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		078312EA22DF15B100B22BCE /* Start DCore */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Start DCore";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "sh \"$SRCROOT/Scripts/stop_dcore.sh\"\nsh \"$SRCROOT/Scripts/start_dcore.sh\"\n";
+		};
 		A112250621FB076E0023E49B /* Carthage */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -3418,6 +3441,7 @@
 				A181489821F859320053F9BE /* ValidationApiTests.swift in Sources */,
 				A1EF306922392935002D2F39 /* ConnectivityTests.swift in Sources */,
 				A114B51A21F9F5E2009F1BA2 /* XCTestManifests.swift in Sources */,
+				07302CA922DE14AB008A4E5D /* Constants.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3431,6 +3455,7 @@
 				A19D4CF321F1AE960069B6CA /* AccountApiMockTests.swift in Sources */,
 				A1A2FBC02242ECC4003641EA /* MessagingApiTests.swift in Sources */,
 				A1673B4F21EF3CC3008FF560 /* OperationApiTests.swift in Sources */,
+				07302CA822DE14AB008A4E5D /* Constants.swift in Sources */,
 				OBJ_1088 /* AssetApiTests.swift in Sources */,
 				07871B1222D5FE0900177B31 /* ContentApiTests.swift in Sources */,
 				A1673B5221EF43CA008FF560 /* GeneralApiTests.swift in Sources */,

--- a/Tests/DCoreKitTests/AccountApiMockTests.swift
+++ b/Tests/DCoreKitTests/AccountApiMockTests.swift
@@ -6,7 +6,7 @@ import RxBlocking
 
 class AccountApiMockTests: MockTestCase {
 
-    private let url = "https://testnet-api.dcore.io/rpc"
+    private let url = DCore.TestConstant.httpUrl
 
     func testGetAccountByIdUsingRest() {
         

--- a/Tests/DCoreKitTests/AccountApiTests.swift
+++ b/Tests/DCoreKitTests/AccountApiTests.swift
@@ -5,8 +5,8 @@ import RxBlocking
 
 final class AccountApiTests: XCTestCase {
 
-    private let rest = DCore.Sdk.create(forRest: "https://testnet-api.dcore.io/rpc")
-    private let wss = DCore.Sdk.create(forWss: "wss://testnet-api.dcore.io")
+    private let rest = DCore.Sdk.create(forRest: DCore.TestConstant.httpUrl)
+    private let wss = DCore.Sdk.create(forWss: DCore.TestConstant.wsUrl)
     
     func testGetAccountByNameUsingRest() {
         let account = try? rest.account.get(byName: "public-account-10").debug().toBlocking().single()
@@ -28,7 +28,7 @@ final class AccountApiTests: XCTestCase {
     }
     
     func testGetAccountIdsByAddressUsingRest() {
-        let ids = try? rest.account.findAllReferences(byKeys: ["DCT51ojM7TUGVpFNUJWX8wi5dYp4iA4brRG16zWfcteVZRZHnkWCF".dcore.address!]).debug().toBlocking().single()
+        let ids = try? rest.account.findAllReferences(byKeys: ["DCT5PwcSiigfTPTwubadt85enxMFC18TtVoti3gnTbG7TN9f9R3Fp".dcore.address!]).debug().toBlocking().single()
         XCTAssert(ids?.first?.contains("1.2.28".dcore.chainObject!) ?? false)
     }
     

--- a/Tests/DCoreKitTests/BalanceApiTests.swift
+++ b/Tests/DCoreKitTests/BalanceApiTests.swift
@@ -5,8 +5,7 @@ import RxBlocking
 
 final class BalanceApiTests: XCTestCase {
 
-    private let rest = DCore.Sdk.create(forRest: "https://testnet-api.dcore.io/rpc")
-    private let restMain = DCore.Sdk.create(forRest: "https://api.decent.ch/rpc")
+    private let rest = DCore.Sdk.create(forRest: DCore.TestConstant.httpUrl)
     
     func testGetBalanceByAccountId() {
    
@@ -27,17 +26,8 @@ final class BalanceApiTests: XCTestCase {
         XCTAssertEqual(balances?.first?.first.id, DCore.Constant.dct)
     }
     
-    func testGetBalanceByAccountIdOnMainnet() {
-        let id = "1.2.11368".dcore.chainObject!
-        
-        let balance = try? restMain.balance.getWithAsset(byAccountId: id).debug().toBlocking().single()
-        XCTAssertEqual(balance?.asset.id, DCore.Constant.dct)
-        XCTAssertEqual(balance?.amount.assetId, DCore.Constant.dct)
-    }
-    
     static var allTests = [
         ("testGetBalanceByAccountId", testGetBalanceByAccountId),
         ("testGetBalanceByAccountIdAndAssetId", testGetBalanceByAccountIdAndAssetId),
-        ("testGetBalanceByAccountIdOnMainnet", testGetBalanceByAccountIdOnMainnet)
     ]
 }

--- a/Tests/DCoreKitTests/BlockApiTests.swift
+++ b/Tests/DCoreKitTests/BlockApiTests.swift
@@ -6,17 +6,17 @@ import RxBlocking
 
 class BlockApiTests: XCTestCase {
     
-    private let rest = DCore.Sdk.create(forRest: "https://testnet-api.dcore.io/rpc")
+    private let rest = DCore.Sdk.create(forRest: DCore.TestConstant.httpUrl)
     
     func testGetBlockHeaderUsingRest() {
-        let num: UInt64 = 1000
+        let num: UInt64 = 1
         
         let result = try? rest.block.getHeader(byNum: num).debug().toBlocking().single()
         XCTAssertEqual(result?.num, num)
     }
     
     func testGetBlockUsingRest() {
-        let num: UInt64 = 1000
+        let num: UInt64 = 1
         
         let result = try? rest.block.get(byNum: num).toBlocking().single()
         XCTAssertNotNil(result)

--- a/Tests/DCoreKitTests/ConnectivityTests.swift
+++ b/Tests/DCoreKitTests/ConnectivityTests.swift
@@ -6,10 +6,10 @@ import RxBlocking
 
 class ConnectivityTests: XCTestCase {
     
-    private let wss = DCore.Sdk.create(forWss: "wss://api.decent.ch")
+    private let wss = DCore.Sdk.create(forWss: DCore.TestConstant.wsUrl)
     
     func testWebSocketReconnection() {
-        let id = "1.2.11368".dcore.chainObject!
+        let id = "1.2.28".dcore.chainObject!
         _ = try? wss.account.get(byId: id).debug().toBlocking().single()
         wss.core.dispose()
         

--- a/Tests/DCoreKitTests/Constants.swift
+++ b/Tests/DCoreKitTests/Constants.swift
@@ -1,0 +1,11 @@
+@testable import DCoreKit
+
+extension DCore {
+    public enum TestConstant {
+
+        //public static let httpUrl: String = "https://testnet.dcore.io" // testnet
+        //public static let wsUrl: String = "wss://testnet-socket.dcore.io" // testnet
+        public static let httpUrl: String = "http://localhost:8090/"
+        public static let wsUrl: String = "ws://localhost:8090/"
+    }
+}

--- a/Tests/DCoreKitTests/ContentApiTests.swift
+++ b/Tests/DCoreKitTests/ContentApiTests.swift
@@ -5,19 +5,11 @@ import RxBlocking
 
 class ContentApiTests: XCTestCase {
     
-    private let wss = DCore.Sdk.create(forWss: "wss://testnet-api.dcore.io")
+    private let wss = DCore.Sdk.create(forWss: DCore.TestConstant.wsUrl)
     
     override func setUp() {
         super.setUp()
         DCore.Logger.xcode(filterCategories: [.network])
-    }
-
-    func testGetContent() {
-        let content = try? wss.content.get(byReference: "http://hello.world.io")
-            .debug()
-            .toBlocking()
-            .single()
-        XCTAssertNotNil(content)
     }
 
     func testSubmitCdnContentOperationAndRemove() {
@@ -34,6 +26,12 @@ class ContentApiTests: XCTestCase {
             publishingFee: .unset,
             fee: .unset).debug().toBlocking().single()
         XCTAssertNotNil(confirm)
+
+        let content = try? wss.content.get(byReference: uri)
+            .debug()
+            .toBlocking()
+            .single()
+        XCTAssertNotNil(content)
 
         let remove = try? wss.content.delete(byReference: uri, author: creds!).debug().toBlocking().single()
         XCTAssertNotNil(remove)
@@ -66,7 +64,6 @@ class ContentApiTests: XCTestCase {
      }
 
     static var allTests = [
-        ("testGetContent", testGetContent),
         ("testSubmitCdnContentOperationAndRemove", testSubmitCdnContentOperationAndRemove),
         ("testUpdateContentOperation", testUpdateContentOperation),
         ]

--- a/Tests/DCoreKitTests/GeneralApiTests.swift
+++ b/Tests/DCoreKitTests/GeneralApiTests.swift
@@ -5,11 +5,11 @@ import RxBlocking
 
 class GeneralApiTests: XCTestCase {
     
-    private let wss = DCore.Sdk.create(forWss: "wss://testnet-api.dcore.io")
+    private let wss = DCore.Sdk.create(forWss: DCore.TestConstant.wsUrl)
     
     func testChainIdUsingWss() {
         let id = try? wss.general.getChainId().debug().toBlocking().single()
-        XCTAssertEqual(id, "a76a2db75f7a8018d41f2d648c766fdb0ddc79ac77104d243074ebdd5186bfbe")
+        XCTAssertEqual(id, "fdeb8d3eeedb7fbbcfed25d81318f1de7820a1056e3a864d14c520e5fafc4019")
     }
     
     func testDynamicGlobalPropsUsingWss() {

--- a/Tests/DCoreKitTests/HistoryApiTests.swift
+++ b/Tests/DCoreKitTests/HistoryApiTests.swift
@@ -6,9 +6,16 @@ import RxBlocking
 
 class HistoryApiTests: XCTestCase {
     
-    private let rest = DCore.Sdk.create(forRest: "https://testnet-api.dcore.io/rpc")
-    private let wss = DCore.Sdk.create(forWss: "wss://testnet-api.dcore.io")
-    private let restMain = DCore.Sdk.create(forRest: "https://api.decent.ch/rpc")
+    private let rest = DCore.Sdk.create(forRest: DCore.TestConstant.httpUrl)
+    private let wss = DCore.Sdk.create(forWss: DCore.TestConstant.wsUrl)
+
+    override func setUp() {
+        super.setUp()
+
+        let pk = "5JMpT5C75rcAmuUB81mqVBXbmL1BKea4MYwVK6voMQLvigLKfrE"
+        let creds = try? Credentials("1.2.28".dcore.chainObject!, wif: pk)
+        _ = try? wss.account.transfer(from: creds!, to: "1.2.27", amount: AssetAmount(1)).toBlocking().single()
+    }
     
     func testGetBalanceHistoryUsingWss() {
         let id = "1.2.28".dcore.chainObject!
@@ -30,20 +37,8 @@ class HistoryApiTests: XCTestCase {
         XCTAssert(result!.first!.history.operation.is(type: TransferOperation.self))
     }
     
-    func testGetBalanceHistoryCheckOnMainnetUsingRest() {
-        let id = "1.2.28".dcore.chainObject!
-        
-        let result = try? restMain.history.findAll(byAccountId: id,
-                                                   assets: [],
-                                                   recipientId: nil,
-                                                   pagination: (.ignore as Pagination).update(limit:2000)
-            ).toBlocking().single()
-        XCTAssertNotNil(result)
-    }
-    
     static var allTests = [
         ("testGetBalanceHistoryUsingWss", testGetBalanceHistoryUsingWss),
         ("testGetBalanceHistoryCheckTransferUsingRest", testGetBalanceHistoryCheckTransferUsingRest),
-        ("testGetBalanceHistoryCheckOnMainnetUsingRest", testGetBalanceHistoryCheckOnMainnetUsingRest),
         ]
 }

--- a/Tests/DCoreKitTests/MessagingApiTests.swift
+++ b/Tests/DCoreKitTests/MessagingApiTests.swift
@@ -6,7 +6,29 @@ import RxBlocking
 
 class MessagingApiTests: XCTestCase {
     
-    private let wss = DCore.Sdk.create(forWss: "wss://testnet-api.dcore.io")
+    private let wss = DCore.Sdk.create(forWss: DCore.TestConstant.wsUrl)
+
+    func testDoSendUnencryptedMessage() {
+        let result = try? wss.messaging.sendUnencrypted(
+            to: "1.2.28",
+            message: "test123",
+            credentials: Credentials(
+                "1.2.27".asChainObject(), wif: "5Hxwqx6JJUBYWjQNt8DomTNJ6r6YK8wDJym4CMAH1zGctFyQtzt"
+            )
+        ).debug().toBlocking().single()
+        XCTAssertNotNil(result)
+    }
+    
+    func testDoSendEncryptedMessage() {
+        let result = try? wss.messaging.send(
+            to: "1.2.28",
+            message: "testEncrypted",
+            credentials: Credentials(
+                "1.2.27".asChainObject(), wif: "5Hxwqx6JJUBYWjQNt8DomTNJ6r6YK8wDJym4CMAH1zGctFyQtzt"
+            )
+        ).debug().toBlocking().single()
+        XCTAssertNotNil(result)
+    }
 
     func testGetAllMessagesByReceiverUsingWss() {
         
@@ -55,36 +77,15 @@ class MessagingApiTests: XCTestCase {
             ).debug().toBlocking().single()
         XCTAssertTrue(result?.isEmpty ?? false)
     }
-
-    func testSendUnencryptedMessage() {
-        let result = try? wss.messaging.sendUnencrypted(
-            to: "1.2.28",
-            message: "test123",
-            credentials: Credentials(
-                "1.2.27".asChainObject(), wif: "5Hxwqx6JJUBYWjQNt8DomTNJ6r6YK8wDJym4CMAH1zGctFyQtzt"
-            )
-        ).debug().toBlocking().single()
-        XCTAssertNotNil(result)
-    }
-
-    func testSendEncryptedMessage() {
-        let result = try? wss.messaging.send(
-            to: "1.2.28",
-            message: "testEncrypted",
-            credentials: Credentials(
-                "1.2.27".asChainObject(), wif: "5Hxwqx6JJUBYWjQNt8DomTNJ6r6YK8wDJym4CMAH1zGctFyQtzt"
-            )
-        ).debug().toBlocking().single()
-        XCTAssertNotNil(result)
-    }
     
     static var allTests = [
+        ("testDoSendUnencryptedMessage", testDoSendUnencryptedMessage),
+        ("testDoSendEncryptedMessage", testDoSendEncryptedMessage),
         ("testGetAllMessagesByReceiverUsingWss", testGetAllMessagesByReceiverUsingWss),
         ("testGetAllMessagesBySenderUsingWss", testGetAllMessagesBySenderUsingWss),
         ("testGetAllResponsesByReceiverUsingWss", testGetAllResponsesByReceiverUsingWss),
         ("testGetAllResponsesBySenderUsingWss", testGetAllResponsesBySenderUsingWss),
         ("testGetAllDecryptedMessagesBySenderUsingWss", testGetAllDecryptedMessagesBySenderUsingWss),
         ("testGetAllDecryptedMessagesBySenderUsingWrongCredentialsUsingWss", testGetAllDecryptedMessagesBySenderUsingWrongCredentialsUsingWss),
-        ("testSendUnencryptedMessage", testSendUnencryptedMessage),
-        ]
+    ]
 }

--- a/Tests/DCoreKitTests/OperationApiTests.swift
+++ b/Tests/DCoreKitTests/OperationApiTests.swift
@@ -5,7 +5,7 @@ import RxBlocking
 
 class OperationApiTests: XCTestCase {
 
-    private let wss = DCore.Sdk.create(forWss: "wss://testnet-api.dcore.io")
+    private let wss = DCore.Sdk.create(forWss: DCore.TestConstant.wsUrl)
     
     override func setUp() {
         super.setUp()

--- a/Tests/DCoreKitTests/SubscriptionApiTests.swift
+++ b/Tests/DCoreKitTests/SubscriptionApiTests.swift
@@ -5,7 +5,7 @@ import RxBlocking
 
 class SubscriptionApiTests: XCTestCase {
 
-    private let rest = DCore.Sdk.create(forRest: "https://testnet-api.dcore.io/rpc")
+    private let rest = DCore.Sdk.create(forRest: DCore.TestConstant.httpUrl)
     
     func testSetBlockAppliedCallbackNotAllowedUsingRest() {
         XCTAssertThrowsError(

--- a/Tests/DCoreKitTests/TransactionApiTests.swift
+++ b/Tests/DCoreKitTests/TransactionApiTests.swift
@@ -6,14 +6,18 @@ import RxBlocking
 
 class TransactionApiTests: XCTestCase {
 
-    private let restMain = DCore.Sdk.create(forRest: "https://api.decent.ch/rpc")
+    private let rest = DCore.Sdk.create(forRest: DCore.TestConstant.httpUrl)
 
-    func testGetTransactionByBlockOnMainnetUsingRest() {
-        let result = try? restMain.transaction.get(byBlockNum: 11343032, positionInBlock: 0).toBlocking().single().id
-        XCTAssertEqual("2e81adea1469bbb62ef1bd4581d5399c66f33ba9", result)
+    func testGetTransaction() {
+        let transaction = try? rest.history.get(byAccountId: "1.2.27", operationId: "1.7.0")
+            .flatMap { self.rest.transaction.get(byBlockNum: $0.history.blockNum, positionInBlock: 0) }
+            .flatMap { self.rest.transaction.get(byId: $0.id) }
+            .toBlocking()
+            .single()
+        XCTAssertNotNil(transaction)
     }
 
     static var allTests = [
-        ("testGetTransactionByBlockOnMainnetUsingRest", testGetTransactionByBlockOnMainnetUsingRest),
+        ("testGetTransaction", testGetTransaction),
     ]
 }

--- a/Tests/DCoreKitTests/ValidationApiTests.swift
+++ b/Tests/DCoreKitTests/ValidationApiTests.swift
@@ -5,8 +5,8 @@ import RxBlocking
 
 class ValidationApiTests: XCTestCase {
     
-    func testVerifyAccountAuthorityViaMainetCredsOnStageUsingRest() {
-        let rest = DCore.Sdk.create(forRest: "https://testnet-api.dcore.io/rpc")
+    func testVerifyAccountAuthorityUsingInvalidAddress() {
+        let rest = DCore.Sdk.create(forRest: DCore.TestConstant.httpUrl)
         let id = "1.2.11368"
         let address = "DCT8Uh7Bk4Qk8uqEZhhwRLvqvJU8YNSQ3SeQ4mTSApWQW456s5dwD".dcore.address!
         let result = try? rest.validation.verifyAccountAuthority(byReference: id, key: address).debug().toBlocking().single()
@@ -14,17 +14,17 @@ class ValidationApiTests: XCTestCase {
         XCTAssertFalse(result ?? true)
     }
     
-    func testVerifyAccountAuthorityViaStageCredsOnMainetUsingRest() {
-        let rest = DCore.Sdk.create(forRest: "https://socket.decentgo.com:8090/rpc")
-        let id = "1.2.1564"
-        let address = "DCT5fSPDaH5Pi9K1fFmTMGLXVVVGu9y96FimJhGdLTSxXCFmMhB3a".dcore.address!
+    func testVerifyAccountAuthorityUsingValidAddress() {
+        let rest = DCore.Sdk.create(forRest: DCore.TestConstant.httpUrl)
+        let id = "1.2.27"
+        let address = "DCT5PwcSiigfTPTwubadt85enxMFC18TtVoti3gnTbG7TN9f9R3Fp".dcore.address!
         let result = try? rest.validation.verifyAccountAuthority(byReference: id, key: address).debug().toBlocking().single()
         
         XCTAssertFalse(result ?? true)
     }
     
     static var allTests = [
-        ("testVerifyAccountAuthorityViaMainetCredsOnStageUsingRest", testVerifyAccountAuthorityViaMainetCredsOnStageUsingRest),
-        ("testVerifyAccountAuthorityViaStageCredsOnMainetUsingRest", testVerifyAccountAuthorityViaStageCredsOnMainetUsingRest)
+        ("testVerifyAccountAuthorityUsingInvalidAddress", testVerifyAccountAuthorityUsingInvalidAddress),
+        ("testVerifyAccountAuthorityUsingValidAddress", testVerifyAccountAuthorityUsingValidAddress)
         ]
 }


### PR DESCRIPTION
AssetApi tests are still running on mainnet, because we need create asset operation to test fetching multiple assets on private test node. This will be fixed in another PR, where `AssetCreateOperation` will be added

SecurityTests test SSL pinning and are making requests to main net node. This behavior is not going to be changed.